### PR TITLE
feat: add tailwind design system

### DIFF
--- a/team-mars-frontend/src/index.css
+++ b/team-mars-frontend/src/index.css
@@ -2,7 +2,6 @@
 @import "tw-animate-css";
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&display=swap');
-@custom-variant dark (&:is(.dark *));
 
 @theme inline {
   /* font heading */
@@ -161,40 +160,6 @@
   /* used for hover */
   --sidebar-accent: oklch(0.9702 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {

--- a/team-mars-frontend/src/index.css
+++ b/team-mars-frontend/src/index.css
@@ -26,8 +26,8 @@
   --h4-weight: 600;
   --h4-leading: 120%;
   --h4-tracking: -0.4px;
-
   
+ 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -145,4 +145,36 @@
   h1, h2, h3, h4 {
     font-family: var(--font-heading);
   }
+
+  h1 {
+  font-size: var(--h1-size);
+  line-height: var(--h1-leading);
+  letter-spacing: var(--h1-tracking);
+  }
+
+  h2 {
+  font-size: var(--h2-size);
+  line-height: var(--h2-leading);
+  letter-spacing: var(--h2-tracking);
+  } 
+
+  h3 {
+    font-size: var(--h3-size);
+    font-weight: var(--h3-weight);
+    line-height: var(--h3-leading);
+    letter-spacing: var(--h3-tracking);
+  }
+  
+  h4 {
+    font-size: var(--h4-size);
+    font-weight: var(--h4-weight);
+    line-height: var(--h4-leading);
+    letter-spacing: var(--h4-tracking);
+  }
+
+  .heading-italic {
+    font-style: italic;
+  }
+
+
 }

--- a/team-mars-frontend/src/index.css
+++ b/team-mars-frontend/src/index.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import "tw-animate-css";
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
@@ -26,8 +27,39 @@
   --h4-weight: 600;
   --h4-leading: 120%;
   --h4-tracking: -0.4px;
-  
- 
+  /* font paragraph */
+  --font-paragraph: 'Cabin', sans-serif;
+  /* paragraph-n-regular */
+  --paragraph-n-regular-size: 16px;     
+  --paragraph-n-regular-weight: 400;
+  --paragraph-n-regular-leading: 150%;
+  --paragraph-n-regular-tracking: 0px;
+  /* paragraph-n-medium */
+  --paragraph-n-medium-size: 16px;
+  --paragraph-n-medium-weight: 500;
+  --paragraph-n-medium-leading: 150%;
+  --paragraph-n-medium-tracking: 0px;
+  /* paragraph-s-regular */
+  --paragraph-s-regular-size: 14px;     
+  --paragraph-s-regular-weight: 400;
+  --paragraph-s-regular-leading: 150%;
+  --paragraph-s-regular-tracking: 0.1px;
+  /* paragraph-s-medium */
+  --paragraph-s-medium-size: 14px;
+  --paragraph-s-medium-weight: 500;
+  --paragraph-s-medium-leading: 150%;
+  --paragraph-s-medium-tracking: 0.1px;
+  /* paragraph-xs-regular */
+  --paragraph-xs-regular-size: 12px;
+  --paragraph-xs-regular-weight: 400;
+  --paragraph-xs-regular-leading: 150%;
+  --paragraph-xs-regular-tracking: 0.2px;
+  /* paragraph-xs-medium */
+  --paragraph-xs-medium-size: 12px;
+  --paragraph-xs-medium-weight: 500;
+  --paragraph-xs-medium-leading: 150%;
+  --paragraph-xs-medium-tracking: 0.2px;
+  /* border radius */
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -141,44 +173,90 @@
   body {
     @apply bg-background text-foreground;
   }
-  
-  h1, h2, h3, h4 {
-    font-family: var(--font-heading);
-  }
-
+  /* Heading classes */
   h1 {
+    font-family: var(--font-heading);
     font-size: var(--h1-size);
+    font-weight: var(--h1-weight);
     line-height: var(--h1-leading);
     letter-spacing: var(--h1-tracking);
     margin: 0;
   }
-
   h2 {
+    font-family: var(--font-heading);
     font-size: var(--h2-size);
+    font-weight: var(--h2-weight);
     line-height: var(--h2-leading);
     letter-spacing: var(--h2-tracking);
     margin: 0;
   } 
-
   h3 {
+    font-family: var(--font-heading);
     font-size: var(--h3-size);
     font-weight: var(--h3-weight);
     line-height: var(--h3-leading);
     letter-spacing: var(--h3-tracking);
     margin: 0;
   }
-
   h4 {
+    font-family: var(--font-heading);
     font-size: var(--h4-size);
     font-weight: var(--h4-weight);
     line-height: var(--h4-leading);
     letter-spacing: var(--h4-tracking);
     margin: 0;
   }
-
   .heading-italic {
     font-style: italic;
   }
-
+  /* Paragraph classes */
+  .paragraph-n-regular {
+    font-family: var(--font-paragraph);
+    font-size: var(--paragraph-n-regular-size);
+    font-weight: var(--paragraph-n-regular-weight);
+    line-height: var(--paragraph-n-regular-leading);
+    letter-spacing: var(--paragraph-n-regular-tracking);
+    margin: 0;
+  }
+  .paragraph-n-medium {
+    font-family: var(--font-paragraph);
+    font-size: var(--paragraph-n-medium-size);
+    font-weight: var(--paragraph-n-medium-weight);
+    line-height: var(--paragraph-n-medium-leading);
+    letter-spacing: var(--paragraph-n-medium-tracking);
+    margin: 0;
+  }
+  .paragraph-s-regular {
+    font-family: var(--font-paragraph);
+    font-size: var(--paragraph-s-regular-size);
+    font-weight: var(--paragraph-s-regular-weight);
+    line-height: var(--paragraph-s-regular-leading);
+    letter-spacing: var(--paragraph-s-regular-tracking);
+    margin: 0;
+  }
+  .paragraph-s-medium {
+    font-family: var(--font-paragraph);
+    font-size: var(--paragraph-s-medium-size);
+    font-weight: var(--paragraph-s-medium-weight);
+    line-height: var(--paragraph-s-medium-leading);
+    letter-spacing: var(--paragraph-s-medium-tracking);
+    margin: 0;
+  }
+  .paragraph-xs-regular {
+    font-family: var(--font-paragraph);
+    font-size: var(--paragraph-xs-regular-size);
+    font-weight: var(--paragraph-xs-regular-weight);
+    line-height: var(--paragraph-xs-regular-leading);
+    letter-spacing: var(--paragraph-xs-regular-tracking);
+    margin: 0;
+  }
+  .paragraph-xs-medium {
+    font-family: var(--font-paragraph);
+    font-size: var(--paragraph-xs-medium-size);
+    font-weight: var(--paragraph-xs-medium-weight);
+    line-height: var(--paragraph-xs-medium-leading);
+    letter-spacing: var(--paragraph-xs-medium-tracking);
+    margin: 0;
+  }
 
 }

--- a/team-mars-frontend/src/index.css
+++ b/team-mars-frontend/src/index.css
@@ -147,15 +147,17 @@
   }
 
   h1 {
-  font-size: var(--h1-size);
-  line-height: var(--h1-leading);
-  letter-spacing: var(--h1-tracking);
+    font-size: var(--h1-size);
+    line-height: var(--h1-leading);
+    letter-spacing: var(--h1-tracking);
+    margin: 0;
   }
 
   h2 {
-  font-size: var(--h2-size);
-  line-height: var(--h2-leading);
-  letter-spacing: var(--h2-tracking);
+    font-size: var(--h2-size);
+    line-height: var(--h2-leading);
+    letter-spacing: var(--h2-tracking);
+    margin: 0;
   } 
 
   h3 {
@@ -163,13 +165,15 @@
     font-weight: var(--h3-weight);
     line-height: var(--h3-leading);
     letter-spacing: var(--h3-tracking);
+    margin: 0;
   }
-  
+
   h4 {
     font-size: var(--h4-size);
     font-weight: var(--h4-weight);
     line-height: var(--h4-leading);
     letter-spacing: var(--h4-tracking);
+    margin: 0;
   }
 
   .heading-italic {

--- a/team-mars-frontend/src/index.css
+++ b/team-mars-frontend/src/index.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 @import "tw-animate-css";
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400..700;1,400..700&display=swap');
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
@@ -64,21 +64,35 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+  /* colors */
   --color-background: var(--background);
+  --color-background-alt: var(--background-alt);
+
   --color-foreground: var(--foreground);
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
   --color-popover: var(--popover);
   --color-popover-foreground: var(--popover-foreground);
+  /* primary colors */
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
+  --color-primary-alt: var(--primary-alt);
+  --color-primary-alt-foreground: var(--primary-alt-foreground);
+  /* secondary colors */
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary-alt: var(--secondary-alt);
+  --color-secondary-alt-foreground: var(--secondary-alt-foreground);
+
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
+
   --color-destructive: var(--destructive);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -87,49 +101,66 @@
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
-  --color-sidebar: var(--sidebar);
-  --color-sidebar-foreground: var(--sidebar-foreground);
+  /* sidebar colors */
   --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
   --color-sidebar-accent: var(--sidebar-accent);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-ring: var(--sidebar-ring);
 }
 
 :root {
+  /*neutrals: 
+  white: oklch(0.9851 0 0)
+  gray: oklch(0.7155 0 0)
+  black: oklch(0.1448 0 0)
+  */
   --radius: 0.625rem;
+
   --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --background-alt: oklch(0.3566 0.0454 257.42);
+
+  --foreground: oklch(0.1448 0 0);
+
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card-foreground: oklch(0.1448 0 0);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.1448 0 0);
+
+  --primary: oklch(0.3566 0.0454 257.42);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
+  --primary-alt: oklch(0.5223 0.0703 256.77);
+  --primary-alt-foreground: oklch(0.985 0 0);
+
+  --secondary: oklch(0.8878 0.1826 96.12);
+  --secondary-foreground: oklch(0.1448 0 0);
+  --secondary-alt: oklch(0.6939 0.1426 96.07);
+  --secondary-alt-foreground: oklch(0.985 0 0);
+
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
+
+  --destructive: oklch(0.5603 0.2128 27.66);
+  --success: oklch(0.5273 0.1371 150.07);
+  --warning: oklch(0.7049 0.1867 47.6);
+
+  --border: oklch(0.9219 0 0);
+  --input: oklch(1 0 0);
   --ring: oklch(0.708 0 0);
+  
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
+ 
+  --sidebar-primary: oklch(0.5223 0.0703 256.77);
+  --sidebar-foreground: oklch(0.9851 0 0);
+  /* used for hover */
+  --sidebar-accent: oklch(0.9702 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {

--- a/team-mars-frontend/src/index.css
+++ b/team-mars-frontend/src/index.css
@@ -1,9 +1,33 @@
 @import 'tailwindcss';
 @import "tw-animate-css";
-
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap');
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+  /* font heading */
+  --font-heading: 'Montserrat', sans-serif;
+  /* h1 */
+  --h1-size: 48px;     
+  --h1-weight: 600;
+  --h1-leading: 100%;
+  --h1-tracking: -0.5px;
+  /* h2 */
+  --h2-size: 30px;     
+  --h2-weight: 600;
+  --h2-leading: 100%;
+  --h2-tracking: -0.3px;
+  /* h3 */
+  --h3-size: 24px;     
+  --h3-weight: 600;
+  --h3-leading: 120%;
+  --h3-tracking: -0.5px;
+  /* h4 */
+  --h4-size: 20px;     
+  --h4-weight: 600;
+  --h4-leading: 120%;
+  --h4-tracking: -0.4px;
+
+  
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -116,5 +140,9 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+  
+  h1, h2, h3, h4 {
+    font-family: var(--font-heading);
   }
 }


### PR DESCRIPTION
This pull request makes significant improvements to the global styling in `index.css`, focusing on typography and color theming. The main changes include introducing custom font families and detailed font sizing for headings and paragraphs, refining the color palette and CSS variables for better consistency, and adding new utility classes for typography.

**Typography enhancements:**

* Added imports for Google Fonts (`Montserrat` for headings and `Cabin` for paragraphs), and defined CSS variables for font families, sizes, weights, line heights, and letter spacing for all heading and paragraph levels.
* Introduced new CSS classes for headings (`h1`–`h4`) and paragraphs (`paragraph-n-regular`, `paragraph-n-medium`, etc.) to standardize font usage and spacing throughout the app.

**Color and theme improvements:**

* Refined and expanded CSS variables for background, foreground, primary/secondary colors (including alt variants), and status colors (success, warning, destructive) using the oklch color space for better color accuracy.
* Improved sidebar color variables by reorganizing them and updating their values for consistency with the overall theme.
* Removed dark theme overrides since the app will not pursue such feature.